### PR TITLE
v1.3.2

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -197,6 +197,10 @@ class ExtensionConfig(object):
       cxx.cxxflags += ['-Wno-delete-non-virtual-dtor']
     if cxx.version >= 'gcc-4.8':
       cxx.cflags += ['-Wno-unused-result']
+    if cxx.version >= 'clang-10.0':
+      cxx.cxxflags += ['-Wno-implicit-int-float-conversion']
+    if cxx.version >= 'gcc-8.0':
+      cxx.cxxflags += ['-Wno-class-memaccess']
 
     if have_clang:
       cxx.cxxflags += ['-Wno-implicit-exception-spec-mismatch']

--- a/example_fakeplayers.sp
+++ b/example_fakeplayers.sp
@@ -6,11 +6,11 @@ public Plugin myinfo =
     name = "Example - Fake players",
     author = "yourmnbbn",
     description = "Create fake players by returning fake AS2_INFO and A2S_PLAYER response",
-    version = "1.2.0",
+    version = "1.3.2",
     url = "URL"
 };
 
-int g_iFakePlayerCount = 0;
+//int g_iFakePlayerCount = 0;
 
 public void OnPluginStart()
 {
@@ -20,9 +20,14 @@ public void OnPluginStart()
     FQ_AddFakePlayer(1, "Test Player 1", 100, GetEngineTime());
     FQ_AddFakePlayer(2, "Test Player 3", 80, GetEngineTime());
     FQ_AddFakePlayer(3, "Test Player 3", 60, GetEngineTime());
-    g_iFakePlayerCount = 3;
-    FQ_SetNumClients(g_iFakePlayerCount + GetClientCount());
+
+    //deprecated, use FQ_InfoResponseAutoPlayerCount instead
+    //g_iFakePlayerCount = 3;
+    //FQ_SetNumClients(g_iFakePlayerCount + GetClientCount());
     
+    //Player count in A2S_INFO response will be automatically set according to the fake players you add.
+    FQ_InfoResponseAutoPlayerCount(true);
+
     //You can do like this to only add what you want in A2S_INFO extra data
     FQ_SetEDF(ExtraData_GamePort | ExtraData_ServerTag);
     
@@ -32,27 +37,25 @@ public void OnPluginStart()
 
 public void OnClientDisconnect_Post(int client)
 {
-    FQ_SetNumClients(g_iFakePlayerCount + GetClientCount());
+    //deprecated use FQ_InfoResponseAutoPlayerCount instead
+    //FQ_SetNumClients(g_iFakePlayerCount + GetClientCount());
 
     //As an example to make it more realistic, you can do as the following code, but you have to complete it yourself
     //if(GetRandomInt(0, 1))
     //{
         //FQ_RemoveFakePlayer(3);
-        //g_iFakePlayerCount --;
-        //FQ_SetNumClients(g_iFakePlayerCount + GetClientCount());
     //}
     
 }
 
 public void OnClientPostAdminCheck(int client)
 {
-    FQ_SetNumClients(g_iFakePlayerCount + GetClientCount());
+    //deprecated use FQ_InfoResponseAutoPlayerCount instead
+    //FQ_SetNumClients(g_iFakePlayerCount + GetClientCount());
 
     //As an example to make it more realistic, you can do as the following code, but you have to complete it yourself
     //if(GetRandomInt(0, 1))
     //{
         //FQ_AddFakePlayer(4, "Test Player 4", 20, GetEngineTime());
-        //g_iFakePlayerCount ++;
-        //FQ_SetNumClients(g_iFakePlayerCount + GetClientCount());
     //}
 }

--- a/extension.cpp
+++ b/extension.cpp
@@ -259,6 +259,9 @@ void FakeQuery::SDK_OnUnload()
     SH_REMOVE_MANUALHOOK(Hook_RecvFrom, g_pSteamSocketMgr, SH_STATIC(Hook_RecvFrom), true);
     gameconfs->CloseGameConfigFile(g_pGameConfig);
     SH_REMOVE_HOOK(IServerGameDLL, GameServerSteamAPIActivated, gamedll, SH_MEMBER(this, &FakeQuery::Hook_GameServerSteamAPIActivated), true);
+
+    if(g_pDetourFunc)
+        g_pDetourFunc->DisableDetour();
 }
 
 void FakeQuery::Hook_GameServerSteamAPIActivated(bool bActivated)

--- a/extension.cpp
+++ b/extension.cpp
@@ -95,12 +95,6 @@ int Hook_RecvFrom(int s, char* buf, int len, int flags, netadr_s* from)
     if(!SteamGameServer())  //Necessary interface is not ready yet
         RETURN_META_VALUE(MRES_IGNORED, 0);
     
-    int host_info_show = g_pCvar->FindVar("host_info_show")->GetInt();
-
-    //A2S_INFO was disabled by server
-    if(host_info_show < 1)
-        RETURN_META_VALUE(MRES_IGNORED, 0);
-    
     int recvSize = META_RESULT_ORIG_RET(int);
     if(recvSize < 4)
         RETURN_META_VALUE(MRES_IGNORED, 0);
@@ -117,7 +111,7 @@ int Hook_RecvFrom(int s, char* buf, int len, int flags, netadr_s* from)
             RETURN_META_VALUE(MRES_IGNORED, 0);
         }
         
-        switch(host_info_show)
+        switch(g_pCvar->FindVar("host_info_show")->GetInt())
         {
             case 2: //host_info_show 2 need challenge when requesting A2S_INFO
                 {

--- a/fakequeries.inc
+++ b/fakequeries.inc
@@ -203,7 +203,15 @@ native void FQ_RemoveAllFakePlayer();
  */
 native void FQ_SetFakePlayerDisplayNum(int iDisplayNum);
 
-
+/**
+ * Set whether the real players count in A2S_INFO response be automatically controlled by the
+ * fake players you've added. By default this is false. 
+ * Note that FQ_SetNumClients can override this.
+ *
+ * @param bAuto               Self explanation.
+ * @noreturn
+ */
+native void FQ_InfoResponseAutoPlayerCount(bool bAuto);
 
 //Do not edit below this
 public Extension __ext_fakequeries = 
@@ -244,5 +252,6 @@ public void __ext_fakequeries_SetNTVOptional()
     MarkNativeAsOptional("FQ_RemoveFakePlayer");
     MarkNativeAsOptional("FQ_RemoveAllFakePlayer");
     MarkNativeAsOptional("FQ_SetFakePlayerDisplayNum");
+    MarkNativeAsOptional("FQ_InfoResponseAutoPlayerCount");
 }
 #endif

--- a/fakequeries.inc
+++ b/fakequeries.inc
@@ -206,7 +206,7 @@ native void FQ_SetFakePlayerDisplayNum(int iDisplayNum);
 /**
  * Set whether the real players count in A2S_INFO response be automatically controlled by the
  * fake players you've added. By default this is false. 
- * Note that FQ_SetNumClients can override this.
+ * Note that this can override FQ_SetNumClients.
  *
  * @param bAuto               Self explanation.
  * @noreturn

--- a/natives.cpp
+++ b/natives.cpp
@@ -476,8 +476,11 @@ void CReturnA2sInfo::SetNumClients(uint8_t iClientCount, bool bDefault)
 
 uint8_t CReturnA2sInfo::GetNumClients()
 {
+    if(m_bInfoResponseAutoPlayerCount)
+        return g_ReturnA2sPlayer.GetTotalPlayersCount();
+    
     if(m_bDefaultNumClients)
-        return m_bInfoResponseAutoPlayerCount ? g_ReturnA2sPlayer.GetTotalPlayersCount() : g_pServer->GetNumClients();
+        return g_pServer->GetNumClients();
     else
         return m_iNumClients;
 }

--- a/natives.h
+++ b/natives.h
@@ -67,13 +67,14 @@ public:
     
     void ClearAllFakePlayer() { m_FakePlayers.clear();}
     
+    uint8_t GetTotalPlayersCount();
+
 private:
     //Get real client status
     bool GetPlayerStatus(int iClientIndex, PlayerInfo_t& info);
 
 private:
     uint8_t m_FakePlayerDisplayNum;
-    uint8_t m_TotalClientsCount;
     std::vector<PlayerInfo_t> m_FakePlayers;
 };
 
@@ -136,6 +137,8 @@ public:
     void SetEDF(uint8_t edf, bool bDefault = false);
     uint8_t GetEDF();  
 
+    void SetInfoResponseAutoPlayerCount(bool bAuto);
+
 private:
     
     //Real information
@@ -191,6 +194,8 @@ private:
 
     uint8_t m_EDF;
     bool m_bDefaultEDF;
+
+    bool m_bInfoResponseAutoPlayerCount;
 };
 
 #endif // _INCLUDE_FAKEQUERIES_NATIVE_H_

--- a/smsdk_config.h
+++ b/smsdk_config.h
@@ -40,7 +40,7 @@
 /* Basic information exposed publicly */
 #define SMEXT_CONF_NAME			"Fake Queries"
 #define SMEXT_CONF_DESCRIPTION	"Return fake A2S_INFO and AS2_PLAYER response"
-#define SMEXT_CONF_VERSION		"1.3.1"
+#define SMEXT_CONF_VERSION		"1.3.2"
 #define SMEXT_CONF_AUTHOR		"Yourmnbbn"
 #define SMEXT_CONF_URL			"https://github.com/yourmnbbn"
 #define SMEXT_CONF_LOGTAG		"Fake Queries"


### PR DESCRIPTION
## Changes
- Fix A2S_PLAYER response will be affected by cvar host_info_show
- Fix detour not disabled on extension unload 
- Add native FQ_InfoResponseAutoPlayerCount, which will automatically change the player count according to the fake players you've added in A2S_INFO response. You don't have to manually manage it any longer.